### PR TITLE
Fix problems with node-youtube-dl when network connection is too fast

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -114,8 +114,7 @@ var getHumanTime = function(ms) {
   return "" + str + ms + " ms";
 };
 
-
-var regex = /(\d+\.\d)% of (\d+\.\d+\w) at\s+([^\s]+) ETA ((\d|-)+:(\d|-)+)/;
+var regex = /(\d+\.\d)% of (\d+\.\d+\w) at\s+([^\s]+) (?:ETA|eta) ((\d|-)+:(\d|-)+)/;
 
 // main download function
 exports.download = function(url, dest, args) {
@@ -135,43 +134,60 @@ exports.download = function(url, dest, args) {
 
   var filename, size, state;
   var emitter = new EventEmitter();
+  var partial = "";
 
-  youtubedl.stdout.on('data', function(data) {
+  youtubedl.stdout.on('data', function(chunk) {
+    if (chunk) {
+      if ("" != partial) {
+        chunk = partial + chunk;
+        partial = "";
+      }
+    }
+
     var pos, result;
-    data = data.toString();
+    var str = chunk.toString();
+    // Bit hack, some rows are prepended with \r and some are appended with \n
+    str = str.replace(/\r/g, "\n");
+    var datas = str.split("\n");
+    if (!str.match(/\n?$/)) {
+      partial += datas.pop();
+    }
 
-    // check if video is uploading so script can start
-    // calling the download progress function
-    if (state === 'download' && (result = regex.exec(data))) {
+    for (var i in datas) {
+      var data = datas[i];
+      if(data.length == 0) continue; // Drop empty lines, no need to process
 
-      // if this is the first progress display, grab file size
-      if (!size) {
-        emitter.emit(state, {
-            filename : filename
-          , size     : size = result[2]
+      // check if video is uploading so script can start
+      // calling the download progress function, if filename is set
+      if (filename && state === 'download' && (result = regex.exec(data))) {
+
+        // if this is the first progress display, grab file size
+        if (!size) {
+          emitter.emit(state, {
+            filename:filename, size:size = result[2]
+          });
+        }
+
+        if (result[3] !== '---b/s') {
+          speed.push(toBytes(result[3].substring(0, result[3].length -2 )));
+        }
+        emitter.emit('progress', {
+          percent:result[1], speed:result[3], eta:result[4]
         });
+
+        // about to start downloading video, only in beginning
+      } else if (!filename && (pos = data.indexOf('[download] Destination:')) === 0) {
+        state = 'download';
+        filename = data.substring(24, data.length);
+
+        // check if this is any other state
+      } else if ((pos = data.indexOf(']')) !== -1) {
+        state = data.substring(pos + 2, data.length);
+        emitter.emit(state);
       }
-
-      if (result[3] !== '---b/s') {
-        speed.push(toBytes(result[3].substring(0, result[3].length - 2)));
-      }
-      emitter.emit('progress', {
-          percent : result[1]
-        , speed   : result[3]
-        , eta     : result[4]
-      });
-
-    // about to start downloading video
-    } else if ((pos = data.indexOf('[download] ')) === 0) {
-      state = 'download';
-      filename = data.substring(24, data.length - 1);
-
-    // check if this is any other state
-    } else if ((pos = data.indexOf(']')) !== -1) {
-      state = data.substring(pos + 2, data.length - 1);
-      emitter.emit(state);
     }
   });
+
 
   youtubedl.stderr.on('data', function(data) {
     data = data.toString().trim();


### PR DESCRIPTION
node-youtube-dl has problems with filename parsing and buffer parsing in general when connection speed is very fast as buffer can contain multiple lines of text.

Edge cases fixed:
- Multiple lines of data per buffer
- Buffer sends only partial line
- Progress report is retrieved before filename is set
