### PR TITLE
removed check for query.v that breaks soundcloud functionality

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -43,10 +43,7 @@ exports.download = function(urladdr, dest, args) {
 
   // Get ID from urladdr.
   var query = url.parse(urladdr, true).query;
-  if (!query.v) {
-    throw new Error('Video URL must contain a video ID.');
-  }
-  var id = query.v;
+  var id = query.v || '';
 
   // Call youtube-dl.
   var youtubedl = spawn(file, args, { cwd: dest });


### PR DESCRIPTION
The error thrown when query.v is unavailable, breaks functionality for using soundcloud and maybe mixcloud.  I just removed that and gave id an empty string if query.v is not available.
