### PR TITLE
Fix - Incorrect youtube video URL

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -23,7 +23,7 @@ fs.exists(file, function(exists) {
 
 var progressRegex = /(\d+(?:\.\d)?)% of (\d+\.\d+\w+) at\s+([^\s]+) ETA ((\d|-)+:(\d|-)+)/;
 
-var isYouTubeRegex = /^(https?:\/\/www\.|https?:\/\/)?(youtube\.com|youtu\.be)\//;
+var isYouTubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\//;
 
 // check if win
 var isWin = /^win/.test(process.platform);
@@ -52,10 +52,8 @@ exports.download = function(urladdr, dest, args) {
   // Get possible IDs.
   var id = query.v || '';
 
-  // Check for youtube video url.
-  var isYouTube = isYouTubeRegex.test(urladdr);
-
-  if (isYouTube && !id) {
+  // Check for long and short youtube video url.
+  if (!id && isYouTubeRegex.test(urladdr)) {
     // Get possible IDs for youtu.be from urladdr.
     id = details.pathname.slice(1);
   }


### PR DESCRIPTION
match possible long and short youtube urls throw only if none match
