### PR TITLE
fix - youtube-dl incorrect !download

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 *.webm
 node_modules
 test
+bin/version


### PR DESCRIPTION
it looks like `bin/version` is included in the published `npm package.tgz`. This is reporting incorrect `Already up to date xxxx.xx.xx` during `npm install youtube-dl` while `bin\youtube-dl` still contains old version `2012.02.27`
