### PR TITLE
fix for win py2.x / py3.x

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -97,16 +97,16 @@ function call(video, args, options, callback) {
     args.push('http://www.youtube.com/watch?v=' + id);
   }
 
-  var opt = [file, args, ''];
+  var opt = [file, args];
 
-  if (isWin) { opt = ['python', [file].concat(args), '\r']; }
+  if (isWin) { opt = ['python', [file].concat(args)]; }
 
   // Call youtube-dl.
   execFile(opt[0], opt[1], function(err, stdout, stderr) {
     if (err) return callback(err);
     if (stderr) return callback(new Error(stderr.slice(7)));
 
-    var data = stdout.trim().split(opt[2] + '\n');
+    var data = stdout.trim().split(/\r?\n/);
     callback(null, data);
   });
 


### PR DESCRIPTION
It looks like py3.x on win doesn't require '\r' to properly split the end of the lines but py2.x does. This should work for both cases plus osx and *nix
