### PR TITLE
package: add binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "Przemyslaw Pluta <przemyslawplutadev@gmail.com> (http://przemyslawpluta.com)"
   ],
   "main": "./lib/youtube-dl.js",
+  "bin" : "./bin/youtube-dl",
   "directories": {
     "lib": "./lib"
   },


### PR DESCRIPTION
When install `youtube-dl` with 

```
npm i youtube-dl -g
```

Python File `youtube-dl` gets downloaded from [rg3](http://rg3.github.io/youtube-dl/download.html) and puts to bin directory. But it could not be started as any other application installed globaly because there is no record in `package.json`.
