### PR TITLE
fix for failed download with no subtitles when requested

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -18,24 +18,10 @@ fs.exists(file, function(exists) {
 
 var isYouTubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\//;
 var isNoSubsRegex = /WARNING: video doesn't have subtitles/;
-var subs = ['--write-sub', '--write-srt', '--srt-lang', '--all-subs'];
+var subsRegex = /--write-sub|--write-srt|--srt-lang|--all-subs/;
 
 // Check if win.
 var isWin = /^win/.test(process.platform);
-
-/**
- * Regular Expresion IndexOf for Arrays
- *
- * @param {Array.<String>} arr
- * @param {String} rx
- */
-function reIndexOf(arr, rx) {
-    var i;
-    for (i = arr.length - 1; i >= 0; i--) {
-      if (arr[i].toString().match(rx)) { return i; }
-    }
-    return -1;
-}
 
 /**
  * Downloads a video.
@@ -121,12 +107,13 @@ function call(video, args1, args2, options, callback) {
 
       // Try once to download video if no subtitles available
       if (!options.nosubs && isNoSubsRegex.test(stderr)) {
+
+        var i;
         var cleanupOpt = opt[1];
 
-        subs.map(function map(item) {
-          var target = reIndexOf(cleanupOpt, item);
-          if (target > -1) { cleanupOpt.splice(target, 1); }
-        });
+        for (i = cleanupOpt.length - 1; i >= 0; i--) {
+          if (subsRegex.test(cleanupOpt[i])) { cleanupOpt.splice(i, 1); }
+        }
 
         options.nosubs = true;
 


### PR DESCRIPTION
At the moment if video doesn't have subtitles but they were requested by the user `youtube-dl` fails with ... 

``` bash
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: : video doesn't have subtitles

    at /test/youtube-dl/lib/youtube-dl.js:122:23
    at ChildProcess.exithandler (child_process.js:645:7)
    at ChildProcess.emit (events.js:98:17)
    at maybeClose (child_process.js:755:16)
    at Process.ChildProcess._handle.onexit (child_process.js:822:5)
```

... this fix catches and removes possible options passed by the user and tries once to download video only without the subtitles.
