### PR TITLE
fix youtube id filtering

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -85,7 +85,7 @@ function call(video, args1, args2, options, callback) {
     } else {
       // Get possible IDs for youtu.be from urladdr.
       id = details.pathname.slice(1).replace(/^v\//, '');
-      if (id === 'playlist') {
+      if (id || id === 'playlist') {
         args.push(video);
       }
     }


### PR DESCRIPTION
If the youtube link is based on short version like `http://youtu.be/UowkIRSDHfs` the ids were not filtered out properly. This will fix this issue.
