### PR TITLE
Fix when `--verbse` is passed

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -16,6 +16,7 @@ fs.exists(file, function(exists) {
   }
 });
 
+var isDebug = /[debug]/;
 var isYouTubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\//;
 var isNoSubsRegex = /WARNING: video doesn't have subtitles/;
 var subsRegex = /--write-sub|--write-srt|--srt-lang|--all-subs/;
@@ -134,8 +135,14 @@ function call(video, args1, args2, options, callback) {
 
       }
 
-      return callback(new Error(stderr.slice(7)));
+      if (isDebug.test(stderr) && opt[1].indexOf('--verbose') > -1) {
+        console.log('\n' + stderr);
+      } else {
+        return callback(new Error(stderr.slice(7)));
+      }
+
     }
+
     var data = stdout.trim().split(/\r?\n/);
     callback(null, data);
   });


### PR DESCRIPTION
At the moment `youtube-dl` fails when `--verbose` is passed as one of the args. This fixes the issue.
