### PR TITLE
better resolution detection inside getInfo - support for audio only & other formats

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -225,7 +225,7 @@ ytdl.getInfo = function(url, args, options, callback) {
 };
 
 
-var formatsRegex = /^(\d+)\s+([a-z0-9]+)\s+(\d+x\d+|\d+p|audio only)/;
+var formatsRegex = /^(\d+)\s+([a-z0-9]+)\s+(\d+x\d+|\d+p|audio only|\?x\d+|unknown)/;
 
 /**
  * @param {String} url

--- a/test/getFormat.js
+++ b/test/getFormat.js
@@ -4,26 +4,32 @@ var assert = require('assert');
 var video  = 'http://www.youtube.com/watch?v=0k2Zzkw_-0I';
 
 
-var expected = [
-  { id: '0k2Zzkw_-0I', itag: 139, filetype: 'm4a', resolution: 'audio only' },
-  { id: '0k2Zzkw_-0I', itag: 140, filetype: 'm4a', resolution: 'audio only' },
-  { id: '0k2Zzkw_-0I', itag: 171, filetype: 'webm', resolution: 'audio only' },
-  { id: '0k2Zzkw_-0I', itag: 141, filetype: 'm4a', resolution: 'audio only' },
-  { id: '0k2Zzkw_-0I', itag: 172, filetype: 'webm', resolution: 'audio only' },
-  { id: '0k2Zzkw_-0I', itag: 278, filetype: 'webm', resolution: '192x144' },
-  { id: '0k2Zzkw_-0I', itag: 160, filetype: 'mp4', resolution: '192x144' },
-  { id: '0k2Zzkw_-0I', itag: 242, filetype: 'webm', resolution: '320x240' },
-  { id: '0k2Zzkw_-0I', itag: 133, filetype: 'mp4', resolution: '320x240' },
-  { id: '0k2Zzkw_-0I', itag: 243, filetype: 'webm', resolution: '480x360' },
-  { id: '0k2Zzkw_-0I', itag: 134, filetype: 'mp4', resolution: '480x360' },
-  { id: '0k2Zzkw_-0I', itag: 244, filetype: 'webm', resolution: '640x480' },
-  { id: '0k2Zzkw_-0I', itag: 135, filetype: 'mp4', resolution: '640x480' },
-  { id: '0k2Zzkw_-0I', itag: 17, filetype: '3gp', resolution: '176x144' },
-  { id: '0k2Zzkw_-0I', itag: 36, filetype: '3gp', resolution: '320x240' },
-  { id: '0k2Zzkw_-0I', itag: 5, filetype: 'flv', resolution: '400x240' },
-  { id: '0k2Zzkw_-0I', itag: 43, filetype: 'webm', resolution: '640x360' },
-  { id: '0k2Zzkw_-0I', itag: 18, filetype: 'mp4', resolution: '640x360'}
-];
+var expected = {
+  video: [
+    { id: '0k2Zzkw_-0I', itag: 139, filetype: 'm4a', resolution: 'audio only' },
+    { id: '0k2Zzkw_-0I', itag: 140, filetype: 'm4a', resolution: 'audio only' },
+    { id: '0k2Zzkw_-0I', itag: 171, filetype: 'webm', resolution: 'audio only' },
+    { id: '0k2Zzkw_-0I', itag: 141, filetype: 'm4a', resolution: 'audio only' },
+    { id: '0k2Zzkw_-0I', itag: 172, filetype: 'webm', resolution: 'audio only' },
+    { id: '0k2Zzkw_-0I', itag: 278, filetype: 'webm', resolution: '192x144' },
+    { id: '0k2Zzkw_-0I', itag: 160, filetype: 'mp4', resolution: '192x144' },
+    { id: '0k2Zzkw_-0I', itag: 242, filetype: 'webm', resolution: '320x240' },
+    { id: '0k2Zzkw_-0I', itag: 133, filetype: 'mp4', resolution: '320x240' },
+    { id: '0k2Zzkw_-0I', itag: 243, filetype: 'webm', resolution: '480x360' },
+    { id: '0k2Zzkw_-0I', itag: 134, filetype: 'mp4', resolution: '480x360' },
+    { id: '0k2Zzkw_-0I', itag: 244, filetype: 'webm', resolution: '640x480' },
+    { id: '0k2Zzkw_-0I', itag: 135, filetype: 'mp4', resolution: '640x480' },
+    { id: '0k2Zzkw_-0I', itag: 17, filetype: '3gp', resolution: '176x144' },
+    { id: '0k2Zzkw_-0I', itag: 36, filetype: '3gp', resolution: '320x240' },
+    { id: '0k2Zzkw_-0I', itag: 5, filetype: 'flv', resolution: '400x240' },
+    { id: '0k2Zzkw_-0I', itag: 43, filetype: 'webm', resolution: '640x360' },
+    { id: '0k2Zzkw_-0I', itag: 18, filetype: 'mp4', resolution: '640x360'}
+  ],
+
+  mixcloud: [
+    { id: 'TheBloodyBeetroots-sbcr-dj-mix-october-2014', itag: 0, filetype: 'mp3', resolution: 'unknown' }
+  ]
+};
 
 vows.describe('getFormats').addBatch({
   'from a video': {
@@ -34,7 +40,19 @@ vows.describe('getFormats').addBatch({
     'formats returned': function(err, formats) {
       assert.isNull(err);
       assert.isArray(formats);
-      assert.deepEqual(formats, expected);
+      assert.deepEqual(formats, expected.video);
+    }
+  },
+
+  'from a mixcloud mix': {
+    'topic': function() {
+      ytdl.getFormats('http://www.mixcloud.com/TheBloodyBeetroots/sbcr-dj-mix-october-2014/', this.callback);
+    },
+
+    'formats returned': function(err, formats) {
+      assert.isNull(err);
+      assert.isArray(formats);
+      assert.deepEqual(formats, expected.mixcloud);
     }
   }
 }).export(module);

--- a/test/getInfo.js
+++ b/test/getInfo.js
@@ -27,6 +27,23 @@ vows.describe('getInfo').addBatch({
       assert.equal(info.resolution, '640x360');
     }
   },
+  'from a soundcloud track': {
+    'topic': function() {
+      var video = 'https://soundcloud.com/erasedtapes/kiasmos-bent';
+      ytdl.getInfo(video, this.callback);
+    },
+    'info returned': function(err, info) {
+      assert.isNull(err);
+      assert.isObject(info);
+      assert.equal(info.id, '147055755');
+      assert.equal(info.title, 'Kiasmos - Bent');
+      assert.isString(info.url);
+      assert.isString(info.thumbnail);
+      assert.isString(info.description);
+      assert.equal(info.filename, 'Kiasmos - Bent-147055755.mp3');
+      assert.equal(info.resolution, 'audio only');
+    }
+  },
   'from a vimeo video': {
     'topic': function() {
       var video = 'https://vimeo.com/6586873';


### PR DESCRIPTION
thanks for the great lib! I just updated and found this small bug fix for non youtube videos that were returning an empty array because the regex was not detecting a row that contained the resolution.

reference for resolutions returned by youtube-dl: https://github.com/rg3/youtube-dl/blob/39f0a2a6b71c5d3cb2e2f8ef1bc3eeeaa6a96971/youtube_dl/YoutubeDL.py#L1178
