### PR TITLE
Fix issue with duration not formatting correctly

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -49,7 +49,7 @@ exports.parseOpts = function(args) {
  */
 exports.formatDuration = function(seconds) {
   var parts = [];
-  parts.push(seconds % 60);
+  parts.push((seconds % 60).toString().length === 1 ? "0" + seconds % 60 : seconds % 60);
   var minutes = Math.floor(seconds / 60);
   if (minutes > 0) {
     parts.push(minutes % 60);


### PR DESCRIPTION
If a song has a number of seconds that is less than ten, then the formatting duration will display the seconds without a leading zero. For example, a song with duration `366` will have a formatted duration of `6:6`. This change adds a ternary operator to check if the seconds in the duration is less than ten seconds and then add a leading zero if necessary.