### PR TITLE
Download correct binary for windows systems

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -16,6 +16,9 @@ function download(url, callback) {
 
     var status = null;
 
+    // download the correct version of the binary based on the platform
+    url = exec(url);
+
     request.get(url, { followRedirect: false }, function(err, res) {
         if (res.statusCode !== 302) {
             return callback(new Error('Did not get redirect for the latest version link. Status: ' + res.statusCode));

--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -22,6 +22,8 @@ if (!fs.existsSync(ytdlBinary)) {
     process.exit(1);
 }
 
+var isWin = (process.platform === 'win32' || process.env.NODE_PLATFORM === 'windows') ? true : false;
+
 var isDebug = /^\[debug\] /;
 var isWarning = /^WARNING: /;
 var isYouTubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\//;
@@ -130,6 +132,23 @@ function call(urls, args1, args2, options, callback) {
         args = args.concat(args2);
     }
     options = options || {};
+
+    // set encoding on windows to support unicode titles
+    if (isWin) {
+        // check if encoding is already set
+        var hasEncoding = false;
+        for (var i = 0; i < args.length; i++) {
+            if (args[i] === '--encoding') {
+                hasEncoding = true;
+                break;
+            }
+        }
+        if (!hasEncoding) {
+            args.push('--encoding');
+            args.push('utf8');
+        }
+    }
+
 
     if (urls !== null) {
         if (typeof urls === 'string') {

--- a/test/getInfo.js
+++ b/test/getInfo.js
@@ -166,11 +166,11 @@ vows.describe('getInfo').addBatch({
             assert.isArray(info[1].formats);
             assert.equal(info[2].id, 'RelentlessOptimisticPterodactylRitzMitz');
             assert.equal(info[2].format_id, '1080');
-            assert.equal(info[2].title, 'Worlds 2017 Play-In: Rampage vs. 1907 Fenerbahçe Espor');
+            assert.equal(info[2].title, 'Riot Games Playing League of Legends - Twitch Clips');
             assert.isString(info[2].url);
             assert.isString(info[2].thumbnail);
-            assert.equal(info[2].fulltitle, 'Worlds 2017 Play-In: Rampage vs. 1907 Fenerbahçe Espor');
-            assert.equal(info[2]._filename, 'Worlds 2017 Play-In - Rampage vs. 1907 Fenerbahçe Espor-RelentlessOptimisticPterodactylRitzMitz.mp4');
+            assert.equal(info[2].fulltitle, 'Riot Games Playing League of Legends - Twitch Clips');
+            assert.equal(info[2]._filename, 'Riot Games Playing League of Legends - Twitch Clips-RelentlessOptimisticPterodactylRitzMitz.mp4');
             assert.equal(info[2].format, '1080 - 1080p');
             assert.equal(info[2].height, 1080);
             assert.equal(info[2]._duration_raw, undefined);


### PR DESCRIPTION
This should fix #169 and #167.

This script was downloading the `youtube-dl` binary on windows and renaming it to `youtube-dl.exe`, which causes the aforementioned issues. 
![youtube-dl-bug](https://user-images.githubusercontent.com/10422156/31865788-6ac521da-b742-11e7-9c43-157297031ac6.png)

Tests are mostly passing.
- The `downloading from multiple videos` (test/getinfo.js:169) test case fails because the actual title of the twitch clip changed. This also fails in ubuntu 17.10.
- The `download playlist thumbnails of a playlist` (`test/playlist.js:80`) test cases seem to fail 
[because of a non-ascii character (`Ñ`) in the filename](https://puu.sh/y4zeR/5f9d013aee.png).
The actual file saved on disk has the proper filename. Calling the youtube-dl binary directly with the same arguments [seems to work fine](https://puu.sh/y4zFg/39cedff485.png).
This test passes on my ubuntu system. Probably a bug with how node communicates with windows programs.

Maybe someone else can take a look at making the tests pass?

### Test environment:
Windows:
Windows 10 Pro x64 version 1709
node v8.7.0
npm 5.4.2

Linux:
Ubuntu 17.10 x64
node v8.7.0
npm 5.4.2

