### PR TITLE
Adding dashes before the video ID

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -154,6 +154,7 @@ function call(urls, args1, args2, options, callback) {
                     }
                 }
             } else {
+                args.push('--');
                 args.push(video);
             }
         }


### PR DESCRIPTION
This allows IDs with a dash as the first character. For example, -vPIhQuqbQ0