### PR TITLE
Consider copyright videos as not available in order to continue on error

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -33,6 +33,7 @@ var videoNotAvailable = new RegExp(
   'This video has been removed by the user|'+
   'Please sign in to view this video|'+
   'This video is no longer available|'+
+  'The uploader has not made this video available|'+
   'This video contains content from'
 );
 var subsRegex = /--write-sub|--write-srt|--srt-lang|--all-subs/;

--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -28,7 +28,13 @@ var isDebug = /^\[debug\] /;
 var isWarning = /^WARNING: /;
 var isYouTubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\//;
 var isNoSubsRegex = /WARNING: video doesn't have subtitles|no closed captions found/;
-var videoNotAvailable = /This video is not available|This video has been removed by the user|Please sign in to view this video|This video is no longer available/;
+var videoNotAvailable = new RegExp(
+  'This video is not available|'+
+  'This video has been removed by the user|'+
+  'Please sign in to view this video|'+
+  'This video is no longer available|'+
+  'This video contains content from'
+);
 var subsRegex = /--write-sub|--write-srt|--srt-lang|--all-subs/;
 
 /**


### PR DESCRIPTION
For videos that are copyright protected. youtube-dl will return errors like:
```
ERROR: 6Y6P2MFVn70: YouTube said: This video contains content from UMG, who has blocked it on copyright grounds.
```

This PR allows `ytdl.getInfo(...)` to continue on copyright protected video errors.