### PR TITLE
Update youtube-dl.js

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -53,6 +53,10 @@ function processData(data, options, stream) {
         headers.Range = 'bytes=' + options.start + '-';
     }
 
+    if (options && options.start > 0 && options.end > 0) {
+        headers.Range = 'bytes=' + options.start + '-' + options.end;
+    }
+
     var req = request({
         url: item.url,
         headers: headers


### PR DESCRIPTION
Added support for end range header that extends the partial file request support. Useful for proxying a stream to a native html5 media element for seek-ability.