### PR TITLE
Setting a path from youtube-dl

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -274,6 +274,24 @@ function parseInfo(data) {
     return info;
 }
 
+/**
+ * Set path from youtube-dl.
+ *
+ * @param {String} path
+ */
+ytdl.setYtdlBinary = function setYtdlBinary(path) {
+    ytdlBinary = path;
+}
+
+/**
+ * Get path from youtube-dl.
+ *
+ * @param {String} path
+ */
+ytdl.getYtdlBinary = function getYtdlBinary() {
+    return ytdlBinary;
+}
+
 
 /**
  * Gets info from a video.

--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -281,7 +281,7 @@ function parseInfo(data) {
  */
 ytdl.setYtdlBinary = function setYtdlBinary(path) {
     ytdlBinary = path;
-}
+};
 
 /**
  * Get path from youtube-dl.
@@ -290,7 +290,7 @@ ytdl.setYtdlBinary = function setYtdlBinary(path) {
  */
 ytdl.getYtdlBinary = function getYtdlBinary() {
     return ytdlBinary;
-}
+};
 
 
 /**


### PR DESCRIPTION
Hi!

I've got this error 
`throw errnoException(err, 'spawn');
`
and I'm packaging a electron app in my linux but for windows the module download the youtube-dl for linux and this does not works on windows. So I created this method to make my day easy. =)

var youtubedl = require('youtube-dl');   
var linux = path.join(path.dirname(remote.getGlobal('globalPath')), 'global', 'linux', 'youtube-dl');  
var win32 = path.join(path.dirname(remote.getGlobal('globalPath')), 'global', 'win32', 'youtube-dl.exe');  
var youtubedlPath = (process.platform === 'win32') ? win32 : linux;     
youtubedl.setYtdlBinary(youtubedlPath);

Please consider this change

