### PR TITLE
Fixed typo & removed redundant line

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -13,7 +13,7 @@ const util = require('./util');
 
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
-const execFileOpts = { mafBuffer: TEN_MEGABYTES }
+const execFileOpts = { maxBuffer: TEN_MEGABYTES }
 
 const detailsPath = path.join(__dirname, '..', 'bin/details')
 
@@ -202,7 +202,6 @@ function call(urls, args1, args2, options = {}, callback) {
           // Get possible IDs for youtu.be from urladdr.
           id = details.pathname.slice(1).replace(/^v\//, '');
           if (id) {
-            if ((id === 'playlist') && !options.maxBuffer) { options.maxBuffer = 7000 * 1024; }
             args.push(video);
             args.unshift('-i');
           }


### PR DESCRIPTION
Fix typo: mafBuffer => maxBuffer. This bug means stdout causes buffer error on some URLs.
Removed line 205 which is no longer relevant since Line 16 already sets the default to be well above the requested amount.