### PR TITLE
Fix ReferenceError: urls is not defined #230

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -24,7 +24,7 @@ function download(url, callback) {
   	  return callback(err);
   	}
 
-    if (response && res.statusCode !== 302) {
+    if (res && res.statusCode !== 302) {
       return callback(new Error('Did not get redirect for the latest version link. Status: ' + res.statusCode));
     }
 

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -20,7 +20,11 @@ function download(url, callback) {
   url = exec(url);
 
   request.get(url, { followRedirect: false }, function (err, res) {
-    if (res.statusCode !== 302) {
+  	if (err) {
+  	  return callback(err);
+  	}
+
+    if (response && res.statusCode !== 302) {
       return callback(new Error('Did not get redirect for the latest version link. Status: ' + res.statusCode));
     }
 

--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -79,7 +79,7 @@ function youtubeDl(args, options, callback) {
       }
     }
 
-    if (passOver && stdout === '' && urls.length > 1) {
+    if (passOver && stdout === '' && typeof urls !== 'undefined' && urls.length > 1) {
       urls.shift();
       return call(urls, args1, args2, options, callback);
     }


### PR DESCRIPTION
When `urls` is not passed as parameter, then youtube-dl will throw a ReferenceError that is uncatchable.