### PR TITLE
Adding a update method on youtube-dl

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -104,7 +104,7 @@ function processData(data, options, stream) {
   const headers = { 'Host': url.parse(item.url).hostname };
 
   Object.assign(headers, data.http_headers);
-  
+
   if (options && options.start > 0) headers.Range = 'bytes=' + options.start + '-';
 
   const req = request({ url: item.url, headers: headers });
@@ -425,4 +425,24 @@ ytdl.getExtractors = function getExtractors(descriptions, options, callback) {
 
   const args = descriptions ? ['--extractor-descriptions'] : ['--list-extractors'];
   return call(null, args, null, options, callback);
+};
+
+/**
+ * @param {!Boolean} descriptions
+ * @param {!Object} options
+ * @param {Function(!Error, Object)} callback
+ */
+ytdl.getUpdate = function getUpdate(descriptions, options, callback) {
+    'use strict';
+    if (typeof options === 'function') {
+        callback = options;
+        options = {};
+    } else if (typeof descriptions === 'function') {
+        callback = descriptions;
+        options = {};
+        descriptions = false;
+    }
+
+    var args = ['-U'];
+    call(null, args, null, options, callback);
 };

--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -426,3 +426,23 @@ ytdl.getExtractors = function getExtractors(descriptions, options, callback) {
   const args = descriptions ? ['--extractor-descriptions'] : ['--list-extractors'];
   return call(null, args, null, options, callback);
 };
+
+/**
+ * @param {!Boolean} descriptions
+ * @param {!Object} options
+ * @param {Function(!Error, Object)} callback
+ */
+ytdl.getUpdate = function getUpdate(descriptions, options, callback) {
+    'use strict';
+    if (typeof options === 'function') {
+        callback = options;
+        options = {};
+    } else if (typeof descriptions === 'function') {
+        callback = descriptions;
+        options = {};
+        descriptions = false;
+    }
+
+    var args = ['-U'];
+    call(null, args, null, options, callback);
+};


### PR DESCRIPTION
Hi!
I've created a new method that updates youtube-dl using args, please consider this change:
```js
/**
 * @param {!Boolean} descriptions
 * @param {!Object} options
 * @param {Function(!Error, Object)} callback
 */
ytdl.getUpdate = function getUpdate(descriptions, options, callback) {
    'use strict';
    if (typeof options === 'function') {
        callback = options;
        options = {};
    } else if (typeof descriptions === 'function') {
        callback = descriptions;
        options = {};
        descriptions = false;
    }

    var args = ['-U'];
    call(null, args, null, options, callback);
};
```

This method helps me to update youtube-dl before trying to ```getInfo()```
