### PR TITLE
fix: add access to ChildProcess from outside

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -22,14 +22,15 @@ const TEN_MEGABYTES = 1000 * 1000 * 10
 const execFileOpts = { maxBuffer: TEN_MEGABYTES }
 
 function youtubeDl (args, options, cb) {
-  execFile(ytdlBinary, args, { ...execFileOpts, ...options }, function done (
-    err,
-    stdout,
-    stderr
-  ) {
-    if (err) return cb(err)
-    return cb(null, stdout.trim().split(/\r?\n/))
-  })
+  return execFile(
+    ytdlBinary,
+    args,
+    { ...execFileOpts, ...options },
+    function done (err, stdout, stderr) {
+      if (err) return cb(err)
+      return cb(null, stdout.trim().split(/\r?\n/))
+    }
+  )
 }
 
 /**


### PR DESCRIPTION
This allows to get access to the child process. For example, to stop it on demand, when call ".exec"