### PR TITLE
fix: log an error if the youtube-dl binary does not exist

### DIFF
--- a/lib/get-binary.js
+++ b/lib/get-binary.js
@@ -8,7 +8,7 @@ const detailsPath = path.join(binPath, 'details')
 
 module.exports = () => {
   if (!existsSync(detailsPath)) {
-    return console.error('ERROR: unable to locate `youtube-dl` at ' + binPath)
+    return console.warn('WARNING: unable to locate `youtube-dl` at ' + binPath)
   }
 
   const details = JSON.parse(readFileSync(detailsPath))

--- a/lib/get-binary.js
+++ b/lib/get-binary.js
@@ -8,7 +8,7 @@ const detailsPath = path.join(binPath, 'details')
 
 module.exports = () => {
   if (!existsSync(detailsPath)) {
-    throw new Error('ERROR: unable to locate `youtube-dl` at ' + binPath)
+    return console.error('ERROR: unable to locate `youtube-dl` at ' + binPath)
   }
 
   const details = JSON.parse(readFileSync(detailsPath))

--- a/lib/get-binary.js
+++ b/lib/get-binary.js
@@ -9,7 +9,7 @@ const detailsPath = path.join(binPath, 'details')
 
 module.exports = () => {
   if (!existsSync(detailsPath)) {
-    return debug('unable to locate `youtube-dl` at ' + binPath)
+    debug('unable to locate `youtube-dl` at ' + binPath)
   }
 
   const details = JSON.parse(readFileSync(detailsPath))

--- a/lib/get-binary.js
+++ b/lib/get-binary.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const debug = require('debug')('youtube-dl')
 const { readFileSync, existsSync } = require('fs')
 const path = require('path')
 
@@ -8,7 +9,7 @@ const detailsPath = path.join(binPath, 'details')
 
 module.exports = () => {
   if (!existsSync(detailsPath)) {
-    return console.warn('WARNING: unable to locate `youtube-dl` at ' + binPath)
+    return debug('unable to locate `youtube-dl` at ' + binPath)
   }
 
   const details = JSON.parse(readFileSync(detailsPath))

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "youtube"
   ],
   "dependencies": {
+    "debug": "~4.1.1",
     "execa": "~3.2.0",
     "hh-mm-ss": "~1.2.0",
     "mkdirp": "~0.5.1",


### PR DESCRIPTION
### Feedback Request

Should I use `console.warn` or `console.error`? Since it is possible to set a custom path for the binary, I feel like this should be a warning instead of an error.

---

At the moment, if the `youtube-dl` binary does not exist for some reason, an error gets thrown.

https://github.com/przemyslawpluta/node-youtube-dl/blob/234182611d1ca6a69c9073a8a4a533bda042146f/lib/get-binary.js#L11

Unfortunately, if you are using `node-youtube-dl` in an electron app, the youtube-dl binary is not accessible from `binPath` by default.

And since an explicit error is thrown, the app will not launch.

```js
const youtubedl = require('youtube-dl') // The app will not launch if the youtube-dl binary is not found
```

Instead of throwing an error, the script can just log an error. The message is still the same but it won't prevent further execution.

```js
console.error('ERROR: unable to locate `youtube-dl` at ' + binPath)
```