### PR TITLE
fix: access to download binary from mirror sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,12 @@ downloader('path/to-binary', function error(err, done) {
 })
 ```
 
+### Environment Variables
+
+Youtube-dl looks for certain environment variables to aid its operations. If Youtube-dl doesn't find them in the environment during the installation step, a lowercased variant of these variables will be used from the [npm config](https://docs.npmjs.com/cli/config) or [yarn config](https://yarnpkg.com/lang/en/docs/cli/config/).
+
+- **YOUTUBE\_DL\_DOWNLOAD\_HOST** - overwrite URL prefix that is used to download the binary file of Youtube-dl. Note: this includes protocol and might even include path prefix. Defaults to `https://yt-dl.org/downloads/latest/youtube-dl`.
+
 ### Tests
 
 Tests are written with [vows](http://vowsjs.org/)
@@ -343,12 +349,6 @@ Tests are written with [vows](http://vowsjs.org/)
 ``` sh
 npm test
 ```
-
-### Environment Variables
-
-Youtube-dl looks for certain environment variables to aid its operations. If Youtube-dl doesn't find them in the environment during the installation step, a lowercased variant of these variables will be used from the [npm config](https://docs.npmjs.com/cli/config) or [yarn config](https://yarnpkg.com/lang/en/docs/cli/config/).
-
-- YOUTUBE\_DL\_DOWNLOAD\_HOST - overwrite URL prefix that is used to download the binary file of Youtube-dl. Note: this includes protocol and might even include path prefix. Defaults to `https://yt-dl.org/downloads/latest/youtube-dl`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,12 @@ Tests are written with [vows](http://vowsjs.org/)
 npm test
 ```
 
+### Environment Variables
+
+Youtube-dl looks for certain environment variables to aid its operations. If Youtube-dl doesn't find them in the environment during the installation step, a lowercased variant of these variables will be used from the [npm config](https://docs.npmjs.com/cli/config) or [yarn config](https://yarnpkg.com/lang/en/docs/cli/config/).
+
+- YOUTUBE\_DL\_DOWNLOAD\_HOST - overwrite URL prefix that is used to download the binary file of Youtube-dl. Note: this includes protocol and might even include path prefix. Defaults to `https://yt-dl.org/downloads/latest/youtube-dl`
+
 ## License
 
 MIT

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -13,9 +13,7 @@ const isWin = flags.includes('--platform=windows') || require('./util').isWin
 let dir, filePath
 const defaultBin = path.join(__dirname, '..', 'bin')
 const defaultPath = path.join(defaultBin, 'details')
-const url = process.env.YOUTUBE_DL_DOWNLOAD_HOST 
-|| process.env.youtube_dl_download_host
-|| 'https://yt-dl.org/downloads/latest/youtube-dl'
+const url = process.env.YOUTUBE_DL_DOWNLOAD_HOST || 'https://yt-dl.org/downloads/latest/youtube-dl'
 
 function download (url, callback) {
   let status

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -13,7 +13,9 @@ const isWin = flags.includes('--platform=windows') || require('./util').isWin
 let dir, filePath
 const defaultBin = path.join(__dirname, '..', 'bin')
 const defaultPath = path.join(defaultBin, 'details')
-const url = 'https://yt-dl.org/downloads/latest/youtube-dl'
+const url = process.env.YOUTUBE_DL_DOWNLOAD_HOST 
+|| process.env.youtube_dl_download_host
+|| 'https://yt-dl.org/downloads/latest/youtube-dl'
 
 function download (url, callback) {
   let status


### PR DESCRIPTION
Installation will fail when network is not access to https://yt-dl.org/downloads/latest/youtube-dl