### PR TITLE
always add range header on data request

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -45,6 +45,8 @@ function processData (data, options, stream) {
 
   if (options && options.start > 0 && options.end > 0) {
     headers.Range = 'bytes=' + options.start + '-' + options.end
+  } else {
+    headers.Range = 'bytes=0-' + item.filesize    
   }
 
   const req = request({

--- a/test/download.js
+++ b/test/download.js
@@ -7,13 +7,14 @@ var video1 = 'http://www.youtube.com/watch?v=90AiXO1pAiA'
 var video2 = 'https://www.youtube.com/watch?v=179MiZSibco'
 var video3 = 'https://www.youtube.com/watch?v=AW8OOp2undg'
 var video4 = 'https://www.youtube.com/watch?v=yy7EUIR0fic'
+var video5 = 'https://www.youtube.com/watch?v=LDDy4m_TiVk'
 var subtitleFile = '1 1 1-179MiZSibco.en.vtt'
 var thumbnailFile = 'Too Many Twists (Heist Night 5_5)-yy7EUIR0fic.jpg'
 
 vows
   .describe('download')
   .addBatch({
-    'a video with format specified': {
+    'a video with video format specified': {
       topic: function () {
         'use strict'
         var dl = ytdl(video1, ['-f', '18'])
@@ -49,6 +50,65 @@ vows
         assert.isObject(data)
         assert.strictEqual(data.id, '90AiXO1pAiA')
         assert.isTrue(/lol-90AiXO1pAiA/.test(data._filename))
+      },
+
+      'file was downloaded': function (err, progress, data) {
+        'use strict'
+        if (err) {
+          throw err
+        }
+
+        // Check existance.
+        var filepath = path.join(__dirname, data._filename)
+        var exists = fs.existsSync(filepath)
+        if (exists) {
+          // Delete file after each test.
+          fs.unlinkSync(filepath)
+        } else {
+          assert.isTrue(exists)
+        }
+      }
+    },
+    'a video with audio format specified': {
+      topic: function () {
+        'use strict'
+        var dl = ytdl(video5, ['-f', '251'])
+        var cb = this.callback
+
+        dl.on('error', cb)
+
+        dl.on('info', function (info) {
+          var pos = 0
+          var progress
+
+          dl.on('data', function (data) {
+            pos += data.length
+            progress = pos / info.size
+          })
+
+          dl.on('end', function () {
+            cb(null, progress, info)
+          })
+
+          var filepath = path.join(__dirname, info._filename)
+          dl.pipe(fs.createWriteStream(filepath))
+        })
+      },
+
+      'data returned': function (err, progress, data) {
+        'use strict'
+        if (err) {
+          throw err
+        }
+
+        assert.strictEqual(progress, 1)
+        assert.isObject(data)
+        assert.strictEqual(data.id, 'LDDy4m_TiVk')
+        assert.isTrue(
+          /Snelle - Smoorverliefd \(prod\. Donda Nisha\)-LDDy4m_TiVk/.test(
+            data._filename
+          )
+        )
       },
 
       'file was downloaded': function (err, progress, data) {

--- a/test/download.js
+++ b/test/download.js
@@ -49,7 +49,6 @@ vows
         assert.isObject(data)
         assert.strictEqual(data.id, '90AiXO1pAiA')
         assert.isTrue(/lol-90AiXO1pAiA/.test(data._filename))
-        assert.strictEqual(data.size, 755906)
       },
 
       'file was downloaded': function (err, progress, data) {

--- a/test/getInfo.js
+++ b/test/getInfo.js
@@ -29,7 +29,7 @@ vows
             'This is also the original I find it hilarious that there are copycat videos!'
         )
         assert.strictEqual(info._filename, 'lol-90AiXO1pAiA.mp4')
-        assert.strictEqual(info.format, '18 - 480x360 (medium)')
+        assert.strictEqual(info.format, '18 - 480x360 (360p)')
         assert.strictEqual(info._duration_raw, 11)
         assert.strictEqual(info._duration_hms, '00:00:11')
         assert.strictEqual(info.duration, '11')
@@ -85,9 +85,9 @@ vows
         )
         assert.strictEqual(info.format, '1080 - 1080p')
         assert.strictEqual(info.height, 1080)
-        assert.strictEqual(info._duration_raw, 29.75)
-        assert.strictEqual(info._duration_hms, '00:00:29.750')
-        assert.strictEqual(info.duration, '29.75')
+        assert.strictEqual(info._duration_raw, 29)
+        assert.strictEqual(info._duration_hms, '00:00:29')
+        assert.strictEqual(info.duration, '29')
         assert.isArray(info.formats)
       }
     },
@@ -125,7 +125,7 @@ vows
         assert.strictEqual(info[0]._filename, 'lol-90AiXO1pAiA.mp4')
         assert.strictEqual(info[0].width, 480)
         assert.strictEqual(info[0].height, 360)
-        assert.strictEqual(info[0].format, '18 - 480x360 (medium)')
+        assert.strictEqual(info[0].format, '18 - 480x360 (360p)')
         assert.strictEqual(info[0]._duration_raw, 11)
         assert.strictEqual(info[0]._duration_hms, '00:00:11')
         assert.strictEqual(info[0].duration, '11')
@@ -148,9 +148,9 @@ vows
         )
         assert.strictEqual(info[1].format, '1080 - 1080p')
         assert.strictEqual(info[1].height, 1080)
-        assert.strictEqual(info[1]._duration_raw, 29.75)
-        assert.strictEqual(info[1]._duration_hms, '00:00:29.750')
-        assert.strictEqual(info[1].duration, '29.75')
+        assert.strictEqual(info[1]._duration_raw, 29)
+        assert.strictEqual(info[1]._duration_hms, '00:00:29')
+        assert.strictEqual(info[1].duration, '29')
         assert.isArray(info[1].formats)
       }
     },
@@ -179,7 +179,7 @@ vows
             'This is also the original I find it hilarious that there are copycat videos!'
         )
         assert.strictEqual(info._filename, 'lol-90AiXO1pAiA.mp4')
-        assert.strictEqual(info.format, '18 - 480x360 (medium)')
+        assert.strictEqual(info.format, '18 - 480x360 (360p)')
         assert.strictEqual(info._duration_raw, 11)
         assert.strictEqual(info._duration_hms, '00:00:11')
         assert.strictEqual(info.duration, '11')

--- a/test/playlist.js
+++ b/test/playlist.js
@@ -65,7 +65,7 @@ vows
         assert.strictEqual(data[0].progress, 1)
         assert.strictEqual(
           data[0].data._filename,
-          'Amy Castle - The Original Cuppycake Video-12Z6pWhM6TA.webm'
+          'Amy Castle - The Original Cuppycake Video-12Z6pWhM6TA.mp4'
         )
         assert.strictEqual(data[1].progress, 1)
         assert.strictEqual(


### PR DESCRIPTION
Hi !

I notice the download was very slow for audio, so I compared with python youtube-dl.
I find out that the youtube server is really slow if the Range: header is missing.
This commit always adds a Range: header

Fixes https://github.com/przemyslawpluta/node-youtube-dl/issues/251