### PR TITLE
PR to fix race condition in downloader - according to #207

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -38,22 +38,22 @@ function download (url, callback) {
     const newVersion = /yt-dl\.org\/downloads\/(\d{4}\.\d\d\.\d\d(\.\d)?)\/youtube-dl/.exec(
       url
     )[1]
-
-    downloadFile.on('response', function response (res) {
+    
+    downloadFile.on('response', function response(res) {
       if (res.statusCode !== 200) {
-        status = new Error('Response Error: ' + res.statusCode)
-        return
+        status = new Error('Response Error: ' + res.statusCode);
+        return;
       }
-      downloadFile.pipe(fs.createWriteStream(filePath, { mode: 493 }))
-    })
+      var outputStream = fs.createWriteStream(filePath, { mode: 493 }); 
+      outputStream.on('close', function end() { 
+        callback(status, newVersion); 
+      });
+      downloadFile.pipe(outputStream);
+    });
 
-    downloadFile.on('error', function error (err) {
-      callback(err)
-    })
-
-    downloadFile.on('end', function end () {
-      callback(status, newVersion)
-    })
+    downloadFile.on('error', function error(err) { 
+      callback(err); 
+    });
   })
 }
 

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -37,23 +37,22 @@ function download (url, callback) {
     const downloadFile = request.get(url)
     const newVersion = /yt-dl\.org\/downloads\/(\d{4}\.\d\d\.\d\d(\.\d)?)\/youtube-dl/.exec(
       url
-    )[1]
-    
-    downloadFile.on('response', function response(res) {
+    )[1] 
+    downloadFile.on('response', function response (res) {
       if (res.statusCode !== 200) {
-        status = new Error('Response Error: ' + res.statusCode);
-        return;
+        status = new Error('Response Error: ' + res.statusCode)
+        return
       }
-      var outputStream = fs.createWriteStream(filePath, { mode: 493 }); 
+      var outputStream = fs.createWriteStream(filePath, { mode: 493 }) 
       outputStream.on('close', function end() { 
-        callback(status, newVersion); 
-      });
-      downloadFile.pipe(outputStream);
-    });
+        callback(status, newVersion) 
+      })
+      downloadFile.pipe(outputStream)
+    })
 
     downloadFile.on('error', function error(err) { 
-      callback(err); 
-    });
+      callback(err)
+    })
   })
 }
 


### PR DESCRIPTION
Quoting #207 

> there is a race condition wherein end can be called on downloadFile before the writeStream finishes writing to disk. If ytdl is invoked immediately after download() runs its callback then ytdl can fail when execFile tries to execute youtube-dl while it is still being written to disk.

**Be aware:**
The code is untested, i just replaced the parts.
In addition i removed the semicolons from the code example from #207 as the project code seems to not use semicolons anymore 