### PR TITLE
Execa function may not pass stdout in callback function if run it with the `{ stdio: 'inherit' }` options.

### DIFF
--- a/lib/youtube-dl.js
+++ b/lib/youtube-dl.js
@@ -22,7 +22,7 @@ const execa = universalify.fromPromise(require('execa'))
 function youtubeDl (args, options, cb) {
   return execa(ytdlBinary, args, options, function done (err, output) {
     if (err) return cb(err)
-    return cb(null, output.stdout.trim().split(/\r?\n/))
+    return cb(null, output.stdout ? output.stdout.trim().split(/\r?\n/) : undefined)
   })
 }
 


### PR DESCRIPTION
Added a check for the presence of stdout in the object passed to the execa callback function.