### PR TITLE
Download fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,10 +354,10 @@ This script parses a couple of flags from `argv`:
 
 ### Update (promise version)
 
-If you are using promises there's now a promise version.
+If you are using promises there's now a promise version, if you don't pass a function as second argument:
 
 ``` js
-const downloader = require('youtube-dl/lib/downloaderPromise')
+const downloader = require('youtube-dl/lib/downloader')
 
 downloader('path/to-binary')
 .then((message) => {

--- a/README.md
+++ b/README.md
@@ -346,6 +346,30 @@ downloader('path/to-binary', function error(err, done) {
 })
 ```
 
+This script parses a couple of flags from `argv`:
+
+* `--platform=windows` forces downloading the Windows version of youtube-dl.
+* `--overwrite` overwrites the existing youtube-dl executable if it exists.
+
+
+### Update (promise version)
+
+If you are using promises there's now a promise version.
+
+``` js
+const downloader = require('youtube-dl/lib/downloaderPromise')
+
+downloader('path/to-binary')
+.then((message) => {
+    console.log(message);
+}).catch((err) => {
+    console.log("err", err);
+    exit(1);
+});
+
+```
+
+
 ### Environment Variables
 
 Youtube-dl looks for certain environment variables to aid its operations. If Youtube-dl doesn't find them in the environment during the installation step, a lowercased variant of these variables will be used from the [npm config](https://docs.npmjs.com/cli/config) or [yarn config](https://yarnpkg.com/lang/en/docs/cli/config/).

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -8,6 +8,7 @@ const fs = require('fs')
 const [, , ...flags] = process.argv
 
 const isWin = flags.includes('--platform=windows') || require('./util').isWin
+const isOverwrite = flags.includes('--overwrite')
 
 // First, look for the download link.
 let dir, filePath
@@ -44,15 +45,18 @@ function download (url, callback) {
         status = new Error('Response Error: ' + res.statusCode)
         return
       }
-      downloadFile.pipe(fs.createWriteStream(filePath, { mode: 493 }))
+
+      const outputStream = fs.createWriteStream(filePath, { mode: 493 });
+      outputStream.on(
+        'close',
+        function end() {
+          callback(status, newVersion);
+        });
+      downloadFile.pipe(outputStream);
     })
 
     downloadFile.on('error', function error (err) {
       callback(err)
-    })
-
-    downloadFile.on('end', function end () {
-      callback(status, newVersion)
     })
   })
 }
@@ -61,8 +65,10 @@ const exec = path => (isWin ? path + '.exe' : path)
 
 function createBase (binDir) {
   dir = binDir || defaultBin
-  mkdirp.sync(dir)
-  if (binDir) mkdirp.sync(defaultBin)
+  if (!fs.existsSync(dir)) {
+    mkdirp.sync(dir)
+    if (binDir) mkdirp.sync(defaultBin)
+  }
   filePath = path.join(dir, exec('youtube-dl'))
 }
 
@@ -73,6 +79,21 @@ function downloader (binDir, callback) {
   }
 
   createBase(binDir)
+
+  // handle overwritin
+  if (fs.existsSync(filePath)) {
+    if (!isOverwrite) {
+      return callback("File exists");
+    }
+    else {
+      try {
+        fs.unlinkSync(filePath);
+      }
+      catch (e) {
+        callback(e);
+      }
+    }
+  }
 
   download(url, function error (err, newVersion) {
     if (err) return callback(err)

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -4,6 +4,7 @@ const request = require('request')
 const mkdirp = require('mkdirp')
 const path = require('path')
 const fs = require('fs')
+const util = require('util')
 
 const [, , ...flags] = process.argv
 
@@ -76,6 +77,9 @@ function downloader (binDir, callback) {
   if (typeof binDir === 'function') {
     callback = binDir
     binDir = null
+  }
+  else if (!callback) {
+    return util.promisify(downloader)(binDir)
   }
 
   createBase(binDir)

--- a/lib/downloaderPromise.js
+++ b/lib/downloaderPromise.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const util = require('util')
-const downloader = require('./downloader')
-
-const downloaderPromise = util.promisify(downloader)
-
-module.exports = downloaderPromise

--- a/lib/downloaderPromise.js
+++ b/lib/downloaderPromise.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const util = require('util')
+const downloader = require('./downloader')
+
+const downloaderPromise = util.promisify(downloader)
+
+module.exports = downloaderPromise

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -1,6 +1,7 @@
 var downloader = require('../lib/downloader')
 
-downloader(function error (err, done) {
-  if (err) return console.log(err.stack)
-  console.log(done)
-})
+downloader().then((message) => {
+  console.log(message);
+}).catch((err) => {
+  console.error(err)
+});


### PR DESCRIPTION
This fixes a few problems with downloads:

* implemented and tested https://github.com/przemyslawpluta/node-youtube-dl/pull/298 (so please cancel that PR), fixes https://github.com/przemyslawpluta/node-youtube-dl/issues/207
* implements `--overwrite` to overwrite the existing youtube-dl. If flag is not present, properly calls the callback with a message instead of throwing an error
* implements a promise-based version of downloader()
* updated README