### PR TITLE
support custom mirror that does not use redirects

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -15,7 +15,9 @@ const isOverwrite = flags.includes('--overwrite')
 let dir, filePath
 const defaultBin = path.join(__dirname, '..', 'bin')
 const defaultPath = path.join(defaultBin, 'details')
-const url = process.env.YOUTUBE_DL_DOWNLOAD_HOST || 'https://yt-dl.org/downloads/latest/youtube-dl'
+const url =
+  process.env.YOUTUBE_DL_DOWNLOAD_HOST ||
+  'https://yt-dl.org/downloads/latest/youtube-dl'
 
 function download (url, callback) {
   let status
@@ -23,42 +25,49 @@ function download (url, callback) {
   // download the correct version of the binary based on the platform
   url = exec(url)
 
-  request.get(url, { followRedirect: false }, function (err, res) {
-    if (err) return callback(err)
+  let downloadFile = request.get(url, { followRedirect: false })
 
-    if (res.statusCode !== 302) {
+  downloadFile.on('response', function (res) {
+    let newVersion = null
+
+    if (res.statusCode === 200) {
+      newVersion = 'custom-mirror'
+      // pointing to a exact version mirror
+      response(res)
+    } else if (res.statusCode !== 302) {
       return callback(
         new Error(
           'Did not get redirect for the latest version link. Status: ' +
             res.statusCode
         )
       )
+    } else {
+      const url = res.headers.location
+      downloadFile = request.get(url)
+      newVersion = /yt-dl\.org\/downloads\/(\d{4}\.\d\d\.\d\d(\.\d)?)\/youtube-dl/.exec(
+        url
+      )[1]
+      downloadFile.on('response', response)
+      downloadFile.on('error', function error (err) {
+        callback(err)
+      })
     }
 
-    const url = res.headers.location
-    const downloadFile = request.get(url)
-    const newVersion = /yt-dl\.org\/downloads\/(\d{4}\.\d\d\.\d\d(\.\d)?)\/youtube-dl/.exec(
-      url
-    )[1]
-
-    downloadFile.on('response', function response (res) {
+    function response (res) {
       if (res.statusCode !== 200) {
         status = new Error('Response Error: ' + res.statusCode)
         return
       }
 
-      const outputStream = fs.createWriteStream(filePath, { mode: 493 });
-      outputStream.on(
-        'close',
-        function end() {
-          callback(status, newVersion);
-        });
-      downloadFile.pipe(outputStream);
-    })
-
-    downloadFile.on('error', function error (err) {
-      callback(err)
-    })
+      const outputStream = fs.createWriteStream(filePath, { mode: 493 })
+      outputStream.on('close', function end () {
+        callback(status, newVersion)
+      })
+      downloadFile.pipe(outputStream)
+    }
+  })
+  downloadFile.on('error', function error (err) {
+    callback(err)
   })
 }
 
@@ -77,8 +86,7 @@ function downloader (binDir, callback) {
   if (typeof binDir === 'function') {
     callback = binDir
     binDir = null
-  }
-  else if (!callback) {
+  } else if (!callback) {
     return util.promisify(downloader)(binDir)
   }
 
@@ -87,14 +95,12 @@ function downloader (binDir, callback) {
   // handle overwritin
   if (fs.existsSync(filePath)) {
     if (!isOverwrite) {
-      return callback("File exists");
-    }
-    else {
+      return callback('File exists')
+    } else {
       try {
-        fs.unlinkSync(filePath);
-      }
-      catch (e) {
-        callback(e);
+        fs.unlinkSync(filePath)
+      } catch (e) {
+        callback(e)
       }
     }
   }


### PR DESCRIPTION
We experienced that the youtube-dl default mirror has not been reachable some time ago. By using our own S3 mirror we can make our system independent of the default mirror.

Modeling the re-direct with S3 is hard, I altered the existing download code to also support a 200 status code instead of a 302 status code, which is interpreted as the first request sending the file.