### PR TITLE
changed yt-dl.org to youtube-dl.org (binary downloads were failing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ downloader('path/to-binary')
 
 Youtube-dl looks for certain environment variables to aid its operations. If Youtube-dl doesn't find them in the environment during the installation step, a lowercased variant of these variables will be used from the [npm config](https://docs.npmjs.com/cli/config) or [yarn config](https://yarnpkg.com/lang/en/docs/cli/config/).
 
-- **YOUTUBE\_DL\_DOWNLOAD\_HOST** - overwrite URL prefix that is used to download the binary file of Youtube-dl. Note: this includes protocol and might even include path prefix. Defaults to `https://yt-dl.org/downloads/latest/youtube-dl`.
+- **YOUTUBE\_DL\_DOWNLOAD\_HOST** - overwrite URL prefix that is used to download the binary file of Youtube-dl. Note: this includes protocol and might even include path prefix. Defaults to `https://youtube-dl.org/downloads/latest/youtube-dl`.
 
 ### Tests
 

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -15,7 +15,7 @@ const isOverwrite = flags.includes('--overwrite')
 let dir, filePath
 const defaultBin = path.join(__dirname, '..', 'bin')
 const defaultPath = path.join(defaultBin, 'details')
-const url = process.env.YOUTUBE_DL_DOWNLOAD_HOST || 'https://yt-dl.org/downloads/latest/youtube-dl'
+const url = process.env.YOUTUBE_DL_DOWNLOAD_HOST || 'https://youtube-dl.org/downloads/latest/youtube-dl'
 
 function download (url, callback) {
   let status
@@ -37,7 +37,7 @@ function download (url, callback) {
 
     const url = res.headers.location
     const downloadFile = request.get(url)
-    const newVersion = /yt-dl\.org\/downloads\/(\d{4}\.\d\d\.\d\d(\.\d)?)\/youtube-dl/.exec(
+    const newVersion = /youtube-dl\.org\/downloads\/(\d{4}\.\d\d\.\d\d(\.\d)?)\/youtube-dl/.exec(
       url
     )[1]
 


### PR DESCRIPTION
youtube-dl.org is the official domain for youtube-dl.
More importantly the TLS certificate of yt-dl.org isn't valid, causing downloads of the binary to fail